### PR TITLE
Add logpoints and hit-condition breakpoints

### DIFF
--- a/crates/dap-types/src/lib.rs
+++ b/crates/dap-types/src/lib.rs
@@ -92,6 +92,10 @@ pub struct SourceBreakpoint {
     pub line: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub condition: Option<String>,
+    #[serde(rename = "hitCondition", skip_serializing_if = "Option::is_none")]
+    pub hit_condition: Option<String>,
+    #[serde(rename = "logMessage", skip_serializing_if = "Option::is_none")]
+    pub log_message: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/debugium-server/src/dap/session.rs
+++ b/crates/debugium-server/src/dap/session.rs
@@ -25,12 +25,16 @@ pub struct TimelineEntry {
     pub stack_summary: Vec<String>,
 }
 
-/// Breakpoint spec with optional condition.
+/// Breakpoint spec with optional condition, hit condition, and log message.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BpSpec {
     pub line: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub condition: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hit_condition: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub log_message: Option<String>,
 }
 
 /// Result of evaluating one watch expression at a stop.
@@ -670,7 +674,7 @@ impl Session {
     /// Set breakpoints on a running session (e.g. from the UI or MCP).
     /// Stores verified specs in `self.breakpoints`.
     pub async fn set_breakpoints(&self, file: &str, lines: Vec<u32>) -> Result<Value> {
-        self.set_breakpoints_with_conditions(file, lines.into_iter().map(|l| BpSpec { line: l, condition: None }).collect()).await
+        self.set_breakpoints_with_conditions(file, lines.into_iter().map(|l| BpSpec { line: l, condition: None, hit_condition: None, log_message: None }).collect()).await
     }
 
     /// Set breakpoints with optional conditions.
@@ -681,6 +685,12 @@ impl Session {
                 let mut obj = serde_json::json!({ "line": s.line });
                 if let Some(cond) = &s.condition {
                     obj["condition"] = Value::String(cond.clone());
+                }
+                if let Some(hc) = &s.hit_condition {
+                    obj["hitCondition"] = Value::String(hc.clone());
+                }
+                if let Some(lm) = &s.log_message {
+                    obj["logMessage"] = Value::String(lm.clone());
                 }
                 obj
             }).collect::<Vec<_>>()
@@ -694,11 +704,15 @@ impl Session {
             .and_then(Value::as_array)
             .map(|arr| arr.iter().enumerate()
                 .filter_map(|(i, b)| {
-                    // Use line from response, or fall back to the input spec at same index
                     let line = b.get("line").and_then(Value::as_u64).map(|l| l as u32)
                         .or_else(|| specs.get(i).map(|s| s.line))?;
-                    let condition = specs.iter().find(|s| s.line == line).and_then(|s| s.condition.clone());
-                    Some(BpSpec { line, condition })
+                    let orig = specs.iter().find(|s| s.line == line);
+                    Some(BpSpec {
+                        line,
+                        condition: orig.and_then(|s| s.condition.clone()),
+                        hit_condition: orig.and_then(|s| s.hit_condition.clone()),
+                        log_message: orig.and_then(|s| s.log_message.clone()),
+                    })
                 })
                 .collect())
             .unwrap_or_else(|| specs.clone());
@@ -779,6 +793,12 @@ async fn attach_child_session(
                 let mut obj = serde_json::json!({ "line": s.line });
                 if let Some(cond) = &s.condition {
                     obj["condition"] = Value::String(cond.clone());
+                }
+                if let Some(hc) = &s.hit_condition {
+                    obj["hitCondition"] = Value::String(hc.clone());
+                }
+                if let Some(lm) = &s.log_message {
+                    obj["logMessage"] = Value::String(lm.clone());
                 }
                 obj
             }).collect::<Vec<Value>>()

--- a/crates/debugium-server/src/mcp/mod.rs
+++ b/crates/debugium-server/src/mcp/mod.rs
@@ -391,16 +391,34 @@ fn tool_list() -> Value {
             },
             {
                 "name": "set_breakpoint",
-                "description": "Set a single breakpoint at a specific file and line. Optionally specify a condition expression. Returns the verified line number from the adapter.",
+                "description": "Set a single breakpoint at a specific file and line. Optionally specify a condition, hit condition, or log message. Returns the verified line number from the adapter.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
                         "session_id": { "type": "string" },
                         "file": { "type": "string", "description": "Absolute path to the source file." },
                         "line": { "type": "integer", "description": "Line number to break on (1-indexed)." },
-                        "condition": { "type": "string", "description": "Optional condition expression — only pause when this evaluates to true." }
+                        "condition": { "type": "string", "description": "Optional condition expression — only pause when this evaluates to true." },
+                        "hit_condition": { "type": "string", "description": "Optional hit count condition — e.g. '== 5' or '>= 10'. Breaks when the hit count satisfies this expression." },
+                        "log_message": { "type": "string", "description": "Optional log message template — turns this into a logpoint that logs instead of stopping. Use {expr} for interpolation, e.g. 'x={x}, len={len(items)}'." }
                     },
                     "required": ["file", "line"]
+                }
+            },
+            {
+                "name": "set_logpoint",
+                "description": "Set a logpoint — a non-stopping breakpoint that logs a message template to the console. The program does NOT pause; the message is printed to debug console output. Use {expression} syntax for interpolation.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "session_id": { "type": "string" },
+                        "file": { "type": "string", "description": "Absolute path to the source file." },
+                        "line": { "type": "integer", "description": "Line number for the logpoint (1-indexed)." },
+                        "message": { "type": "string", "description": "Log message template. Use {expression} for interpolation, e.g. 'counter={counter}, items={len(items)}'." },
+                        "condition": { "type": "string", "description": "Optional condition — only log when this evaluates to true." },
+                        "hit_condition": { "type": "string", "description": "Optional hit count condition — e.g. '>= 10'. Only log when the hit count satisfies this." }
+                    },
+                    "required": ["file", "line", "message"]
                 }
             },
             {
@@ -1521,21 +1539,26 @@ pub async fn dispatch_tool(
             }
         }
 
-        "set_breakpoint" => {
+        "set_breakpoint" | "set_logpoint" => {
             use crate::dap::session::BpSpec;
             let s = session.ok_or_else(|| anyhow::anyhow!("Session '{session_id}' not found"))?;
             let file = args.get("file").and_then(Value::as_str)
                 .ok_or_else(|| anyhow::anyhow!("`file` is required"))?;
             let line = require_u32(&args, "line")?;
             let condition = args.get("condition").and_then(Value::as_str).map(str::to_string);
+            let hit_condition = args.get("hit_condition").and_then(Value::as_str).map(str::to_string);
+            let log_message = args.get("log_message")
+                .or_else(|| args.get("message"))
+                .and_then(Value::as_str).map(str::to_string);
 
-            // Build specs list preserving existing ones, add/replace this line
+            let new_spec = BpSpec { line, condition: condition.clone(), hit_condition: hit_condition.clone(), log_message: log_message.clone() };
+
             let mut existing: Vec<BpSpec> = s.breakpoints.read().await
                 .get(file).cloned().unwrap_or_default();
             if let Some(pos) = existing.iter().position(|s| s.line == line) {
-                existing[pos].condition = condition.clone();
+                existing[pos] = new_spec;
             } else {
-                existing.push(BpSpec { line, condition: condition.clone() });
+                existing.push(new_spec);
             }
             let resp = s.set_breakpoints_with_conditions(file, existing).await?;
             let verified = resp.get("body").and_then(|b| b.get("breakpoints"))
@@ -1547,8 +1570,14 @@ pub async fn dispatch_tool(
                 .unwrap_or(line as u64) as u32;
             let stored = s.breakpoints.read().await.get(file).cloned().unwrap_or_default();
             broadcast_breakpoints_changed(hub, session_id, file, &stored).await;
-            let cond_msg = condition.map(|c| format!(" [condition: {c}]")).unwrap_or_default();
-            Ok(format!("Breakpoint set at {}:{} (verified line: {}){}", file, line, verified, cond_msg))
+
+            let mut extras = Vec::new();
+            if let Some(c) = &condition { extras.push(format!("condition: {c}")); }
+            if let Some(hc) = &hit_condition { extras.push(format!("hit_condition: {hc}")); }
+            if let Some(lm) = &log_message { extras.push(format!("log_message: {lm}")); }
+            let suffix = if extras.is_empty() { String::new() } else { format!(" [{}]", extras.join(", ")) };
+            let kind = if log_message.is_some() { "Logpoint" } else { "Breakpoint" };
+            Ok(format!("{kind} set at {file}:{line} (verified line: {verified}){suffix}"))
         }
 
         "get_console_output" => {

--- a/crates/debugium-server/tests/integration.rs
+++ b/crates/debugium-server/tests/integration.rs
@@ -1534,3 +1534,101 @@ fn v4_wait_for_output_returns_result() {
     // Must return matched + line fields
     assert!(text.contains("\"matched\""), "V4 expected 'matched' field: {text}");
 }
+
+// ─── W. Logpoints & hit-condition breakpoints ─────────────────────────────────
+
+#[test]
+fn w1_set_logpoint_via_set_breakpoint_tool() {
+    require_debugpy!();
+    let srv = ServerGuard::launch(7425, Some(43), None);
+    assert!(srv.wait_up(12), "W1 server never started");
+    assert!(srv.wait_paused(12), "W1 session never paused");
+
+    let mut p = McpProc::start(7425);
+    p.initialize();
+    let r = p.tool_call("set_breakpoint", serde_json::json!({
+        "file": target_py().to_str().unwrap(),
+        "line": 50,
+        "log_message": "step={step}, counter={counter.value}"
+    }));
+    p.stop();
+
+    let text = McpProc::text(&r);
+    assert!(r.get("error").is_none(), "W1 error: {r}");
+    assert!(text.contains("Logpoint"), "expected 'Logpoint' kind in response, got: {text}");
+    assert!(text.contains("log_message"), "expected log_message in extras: {text}");
+}
+
+#[test]
+fn w2_set_logpoint_dedicated_tool() {
+    require_debugpy!();
+    let srv = ServerGuard::launch(7426, Some(43), None);
+    assert!(srv.wait_up(12), "W2 server never started");
+    assert!(srv.wait_paused(12), "W2 session never paused");
+
+    let mut p = McpProc::start(7426);
+    p.initialize();
+    let r = p.tool_call("set_logpoint", serde_json::json!({
+        "file": target_py().to_str().unwrap(),
+        "line": 50,
+        "message": "step={step}"
+    }));
+    p.stop();
+
+    let text = McpProc::text(&r);
+    assert!(r.get("error").is_none(), "W2 error: {r}");
+    assert!(text.contains("Logpoint"), "expected 'Logpoint' in response: {text}");
+}
+
+#[test]
+fn w3_set_breakpoint_with_hit_condition() {
+    require_debugpy!();
+    let srv = ServerGuard::launch(7427, Some(43), None);
+    assert!(srv.wait_up(12), "W3 server never started");
+    assert!(srv.wait_paused(12), "W3 session never paused");
+
+    let mut p = McpProc::start(7427);
+    p.initialize();
+    let r = p.tool_call("set_breakpoint", serde_json::json!({
+        "file": target_py().to_str().unwrap(),
+        "line": 50,
+        "hit_condition": ">= 3"
+    }));
+    p.stop();
+
+    let text = McpProc::text(&r);
+    assert!(r.get("error").is_none(), "W3 error: {r}");
+    assert!(text.contains("hit_condition"), "expected hit_condition in extras: {text}");
+}
+
+#[test]
+fn w4_logpoint_appears_in_list_breakpoints() {
+    require_debugpy!();
+    let srv = ServerGuard::launch(7428, Some(43), None);
+    assert!(srv.wait_up(12), "W4 server never started");
+    assert!(srv.wait_paused(12), "W4 session never paused");
+
+    let mut p = McpProc::start(7428);
+    p.initialize();
+    p.tool_call("set_logpoint", serde_json::json!({
+        "file": target_py().to_str().unwrap(),
+        "line": 50,
+        "message": "counter={counter.value}"
+    }));
+    let r = p.tool_call("list_breakpoints", serde_json::json!({}));
+    p.stop();
+
+    let text = McpProc::text(&r);
+    assert!(r.get("error").is_none(), "W4 error: {r}");
+    assert!(text.contains("log_message"), "expected log_message in listed breakpoints: {text}");
+}
+
+#[test]
+fn w5_set_logpoint_tool_listed_in_tools() {
+    let mut p = McpProc::start(7331);
+    p.initialize();
+    let r = p.send("tools/list", Some(serde_json::json!({})));
+    p.stop();
+    let tools_json = serde_json::to_string(&r).unwrap();
+    assert!(tools_json.contains("set_logpoint"), "set_logpoint not in tools/list");
+}


### PR DESCRIPTION
## Summary
- Adds **logpoints** (non-stopping breakpoints with `logMessage`) that log interpolated templates to the debug console without pausing execution
- Adds **hit-condition breakpoints** (`hitCondition`) that only trigger when the hit count satisfies an expression (e.g. `>= 5`, `== 100`)
- New `set_logpoint` MCP tool as a dedicated convenience entry point
- Extends `set_breakpoint` MCP tool with `log_message` and `hit_condition` parameters
- Forwards new breakpoint fields to child sessions (js-debug, debugpy subprocess attach)

## Test plan
- [x] `w1`: set_breakpoint with log_message returns "Logpoint" kind
- [x] `w2`: set_logpoint dedicated tool works
- [x] `w3`: set_breakpoint with hit_condition
- [x] `w4`: logpoint appears in list_breakpoints with log_message field
- [x] `w5`: set_logpoint appears in tools/list
- [x] Full test suite: 61 tests pass (56 existing + 5 new)

Closes #9, closes #14

Made with [Cursor](https://cursor.com)