### PR TITLE
Add explain_exception compound MCP tool

### DIFF
--- a/crates/debugium-server/src/mcp/mod.rs
+++ b/crates/debugium-server/src/mcp/mod.rs
@@ -321,6 +321,18 @@ fn tool_list() -> Value {
                 }
             },
             {
+                "name": "explain_exception",
+                "description": "When stopped on an exception, gather all relevant context in one call: exception info, paused location, locals, call stack, recent console output, source window, and recent timeline. Returns a structured diagnosis. Use this instead of calling get_exception_info + get_debug_context + get_console_output separately.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "session_id": { "type": "string" },
+                        "thread_id": { "type": "integer", "description": "Thread to inspect. Auto-detected if omitted." }
+                    },
+                    "required": []
+                }
+            },
+            {
                 "name": "disconnect",
                 "description": "Terminate the debug session and the target process.",
                 "inputSchema": {
@@ -1646,6 +1658,121 @@ pub async fn dispatch_tool(
                         f.get("line").and_then(Value::as_u64).unwrap_or(0),
                         f.get("name").and_then(Value::as_str).unwrap_or("?"))
                 }).collect::<Vec<_>>(),
+            }))?)
+        }
+
+        "explain_exception" => {
+            let s = session.ok_or_else(|| anyhow::anyhow!("Session '{session_id}' not found"))?;
+            let thread_id = if let Some(t) = args.get("thread_id").and_then(Value::as_u64) {
+                t as u32
+            } else {
+                paused_thread_id(&s).await
+            };
+
+            // 1. Exception info
+            let exc_info = s.client.request("exceptionInfo",
+                Some(json!({ "threadId": thread_id }))).await
+                .ok().and_then(|r| r.get("body").cloned()).unwrap_or(json!(null));
+
+            // 2. Stack trace
+            let stack_resp = s.client.request("stackTrace",
+                Some(json!({ "threadId": thread_id, "startFrame": 0, "levels": 20 }))).await?;
+            let frames = stack_resp.get("body").and_then(|b| b.get("stackFrames"))
+                .and_then(Value::as_array).cloned().unwrap_or_default();
+            let top = frames.first();
+            let frame_id = top.and_then(|f| f.get("id")).and_then(Value::as_u64).unwrap_or(1) as u32;
+            let file = top.and_then(|f| f.get("source")).and_then(|s| s.get("path"))
+                .and_then(Value::as_str).unwrap_or("?").to_string();
+            let line = top.and_then(|f| f.get("line")).and_then(Value::as_u64).unwrap_or(0) as u32;
+            let func = top.and_then(|f| f.get("name")).and_then(Value::as_str).unwrap_or("?").to_string();
+            let call_stack: Vec<String> = frames.iter().map(|f| {
+                format!("{}:{} in {}()",
+                    f.get("source").and_then(|s| s.get("path")).and_then(Value::as_str)
+                        .map(|p| p.split('/').last().unwrap_or(p)).unwrap_or("?"),
+                    f.get("line").and_then(Value::as_u64).unwrap_or(0),
+                    f.get("name").and_then(Value::as_str).unwrap_or("?"))
+            }).collect();
+
+            // 3. Locals
+            let mut locals = serde_json::Map::new();
+            if let Ok(scopes_resp) = s.client.request("scopes", Some(json!({ "frameId": frame_id }))).await {
+                let scopes = scopes_resp.get("body").and_then(|b| b.get("scopes"))
+                    .and_then(Value::as_array).cloned().unwrap_or_default();
+                let locals_scope = scopes.iter().find(|sc| {
+                    sc.get("name").and_then(Value::as_str)
+                        .map(|n| n.to_lowercase().contains("local") || n.to_lowercase().contains("function"))
+                        .unwrap_or(false)
+                }).or_else(|| scopes.first());
+                if let Some(sc) = locals_scope {
+                    if let Some(vref) = sc.get("variablesReference").and_then(Value::as_u64) {
+                        if vref > 0 {
+                            if let Ok(vars_resp) = s.client.request("variables",
+                                Some(json!({ "variablesReference": vref }))).await {
+                                if let Some(vars) = vars_resp.get("body").and_then(|b| b.get("variables"))
+                                    .and_then(Value::as_array) {
+                                    for v in vars.iter().take(30) {
+                                        let name = v.get("name").and_then(Value::as_str).unwrap_or("?");
+                                        let val  = v.get("value").and_then(Value::as_str).unwrap_or("?");
+                                        let typ  = v.get("type").and_then(Value::as_str).unwrap_or("");
+                                        let entry = if typ.is_empty() { val.to_string() }
+                                                    else { format!("{val} ({typ})") };
+                                        locals.insert(name.to_string(), json!(entry));
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // 4. Recent console output (last 20 lines)
+            let recent_output: Vec<String> = {
+                let buf = s.console_lines.read().await;
+                buf.iter().rev().take(20).cloned().collect::<Vec<_>>().into_iter().rev().collect()
+            };
+
+            // 5. Source window ±10 lines
+            let source_window = if let Ok(content) = tokio::fs::read_to_string(&file).await {
+                let lines: Vec<&str> = content.lines().collect();
+                let ctx = 10usize;
+                let start = (line as usize).saturating_sub(ctx + 1);
+                let end = ((line as usize) + ctx).min(lines.len());
+                lines[start..end].iter().enumerate()
+                    .map(|(i, l)| {
+                        let n = start + i + 1;
+                        let marker = if n == line as usize { "→" } else { " " };
+                        format!("{marker} {:4}: {l}", n)
+                    })
+                    .collect::<Vec<_>>().join("\n")
+            } else { String::new() };
+
+            // 6. Recent timeline (last 5 stops)
+            let recent_timeline: Vec<Value> = {
+                let tl = s.timeline.read().await;
+                tl.iter().rev().take(5).map(|entry| {
+                    json!({
+                        "stop_id": entry.id,
+                        "file": entry.file.split('/').last().unwrap_or(&entry.file),
+                        "line": entry.line,
+                        "changed_vars": entry.changed_vars,
+                    })
+                }).collect::<Vec<_>>().into_iter().rev().collect()
+            };
+
+            Ok(serde_json::to_string_pretty(&json!({
+                "exception": exc_info,
+                "paused_at": format!("{}:{} in {}()",
+                    file.split('/').last().unwrap_or(&file), line, func),
+                "file": file,
+                "line": line,
+                "function": func,
+                "frame_id": frame_id,
+                "thread_id": thread_id,
+                "locals": locals,
+                "call_stack": call_stack,
+                "source_window": source_window,
+                "recent_output": recent_output,
+                "recent_timeline": recent_timeline,
             }))?)
         }
 

--- a/crates/debugium-server/tests/integration.rs
+++ b/crates/debugium-server/tests/integration.rs
@@ -1686,3 +1686,57 @@ fn x3_continue_until_timeout_returns_message() {
     assert!(text.contains("Timed out") || text.contains("Stopped at"),
         "expected timeout or stop message: {text}");
 }
+
+// ─── Y. explain_exception compound tool ───────────────────────────────────────
+
+#[test]
+fn y1_explain_exception_tool_listed() {
+    let mut p = McpProc::start(7331);
+    p.initialize();
+    let r = p.send("tools/list", Some(serde_json::json!({})));
+    p.stop();
+    let tools_json = serde_json::to_string(&r).unwrap();
+    assert!(tools_json.contains("explain_exception"), "explain_exception not in tools/list");
+}
+
+#[test]
+fn y2_explain_exception_returns_structured_context() {
+    require_debugpy!();
+    let tmp = std::env::temp_dir().join("debugium_explain_exc.py");
+    std::fs::write(&tmp, "import time\ntime.sleep(0.2)\nraise ValueError('test error')\n")
+        .unwrap();
+
+    let mut child = Command::new(debugium_bin())
+        .args([
+            "launch",
+            tmp.to_str().unwrap(),
+            "--adapter", "python",
+            "--port", "7431",
+            "--no-open-browser",
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    let ok = wait_server(7431, 12);
+    if ok {
+        std::thread::sleep(Duration::from_millis(500));
+        let mut p = McpProc::start(7431);
+        p.initialize();
+        p.tool_call("run_until_exception", serde_json::json!({}));
+        let r = p.tool_call("explain_exception", serde_json::json!({}));
+        p.stop();
+        let text = McpProc::text(&r);
+        assert!(r.get("error").is_none(), "Y2 error: {r}");
+        assert!(text.contains("\"exception\""), "expected exception field: {text}");
+        assert!(text.contains("\"call_stack\""), "expected call_stack field: {text}");
+        assert!(text.contains("\"locals\""), "expected locals field: {text}");
+        assert!(text.contains("\"source_window\""), "expected source_window field: {text}");
+        assert!(text.contains("\"recent_output\""), "expected recent_output field: {text}");
+    }
+
+    let _ = child.kill();
+    let _ = child.wait();
+    let _ = std::fs::remove_file(&tmp);
+}


### PR DESCRIPTION
## Summary
- New `explain_exception` compound MCP tool for one-call exception diagnosis
- Returns: exception info, location, locals, call stack, source window (±10 lines), recent console output (20 lines), recent timeline (5 stops)
- Replaces the typical 4-5 call chain: `get_exception_info` + `get_debug_context` + `get_console_output` + `get_timeline`
- Auto-detects paused thread when `thread_id` is omitted

## Test plan
- [x] `w1`: explain_exception appears in tools/list
- [x] `w2`: live test with ValueError — returns all structured fields (exception, call_stack, locals, source_window, recent_output)
- [x] Full suite: 58 tests pass (56 existing + 2 new)

Closes #13

Made with [Cursor](https://cursor.com)