### PR TITLE
Add inline variable values in source editor

### DIFF
--- a/crates/debugium-ui/dist/pkg/cm_init.js
+++ b/crates/debugium-ui/dist/pkg/cm_init.js
@@ -293,6 +293,7 @@ function buildExtensions(path) {
         annGutter,
         execArrowGutter,
         execLinePlugin,
+        inlineValuesPlugin,
         themeCompartment.of(currentTheme()),
         langExt(path),
         EditorView.editable.of(false),
@@ -306,6 +307,7 @@ function buildExtensions(path) {
             ".cm-bp-marker": { color: "#e51400", cursor: "pointer" },
             ".cm-ann-marker": { cursor: "default" },
             ".cm-exec-line": { background: "rgba(255,204,0,0.1) !important" },
+            ".cm-inline-value": { color: "rgba(128,128,128,0.75)", fontStyle: "italic", fontSize: "12px" },
         }),
     ];
 }
@@ -386,6 +388,61 @@ window.__cm_set_annotations = function(annotationsJson, filePath) {
     try {
         const items = JSON.parse(annotationsJson);
         items.forEach(a => annSpecs.set(a.line, { message: a.message, color: a.color || "blue" }));
+    } catch (_) {}
+    if (activeView) activeView.dispatch({});
+};
+
+// ─── Inline variable values ─────────────────────────────────────────────────
+
+const inlineValues = new Map(); // line number → formatted string
+
+const inlineValuesPlugin = ViewPlugin.fromClass(class {
+    constructor(view) { this.decorations = this.build(view); }
+    update(update) { this.decorations = this.build(update.view); }
+    build(view) {
+        if (inlineValues.size === 0) return Decoration.none;
+        const builder = new RangeSetBuilder();
+        for (const { from, to } of view.visibleRanges) {
+            for (let pos = from; pos <= to;) {
+                const line = view.state.doc.lineAt(pos);
+                if (inlineValues.has(line.number)) {
+                    const text = inlineValues.get(line.number);
+                    const widget = Decoration.widget({
+                        widget: new InlineValueWidget(text),
+                        side: 1,
+                    });
+                    builder.add(line.to, line.to, widget);
+                }
+                pos = line.to + 1;
+            }
+        }
+        return builder.finish();
+    }
+}, { decorations: v => v.decorations });
+
+class InlineValueWidget {
+    constructor(text) { this.text = text; }
+    toDOM() {
+        const span = document.createElement("span");
+        span.className = "cm-inline-value";
+        span.textContent = "    " + this.text;
+        return span;
+    }
+    eq(other) { return this.text === other.text; }
+    get estimatedHeight() { return -1; }
+    ignoreEvent() { return true; }
+}
+
+/**
+ * Show inline variable values at specific lines.
+ * Called from Rust via `window.__cm_set_inline_values(json)`.
+ * json: array of { line: number, text: string }
+ */
+window.__cm_set_inline_values = function(json) {
+    inlineValues.clear();
+    try {
+        const items = JSON.parse(json);
+        items.forEach(item => inlineValues.set(item.line, item.text));
     } catch (_) {}
     if (activeView) activeView.dispatch({});
 };

--- a/crates/debugium-ui/dist/style.css
+++ b/crates/debugium-ui/dist/style.css
@@ -1481,6 +1481,19 @@ li.session-ended .session-item {
     animation: exec-line-sweep 0.55s ease-out forwards !important;
 }
 
+/* ─── Inline variable values ─────────────────────── */
+.cm-inline-value {
+    color: rgba(140, 140, 140, 0.8);
+    font-style: italic;
+    font-size: 0.88em;
+    pointer-events: none;
+    user-select: none;
+}
+
+.light-mode .cm-inline-value {
+    color: rgba(100, 100, 100, 0.7);
+}
+
 /* ─── Server heartbeat pulse ────────────────────── */
 .server-pulse {
     width: 7px;

--- a/crates/debugium-ui/src/editor.rs
+++ b/crates/debugium-ui/src/editor.rs
@@ -22,6 +22,10 @@ extern "C" {
     /// window.__cm_set_annotations(annotationsJson, filePath)
     #[wasm_bindgen(js_namespace = window, js_name = __cm_set_annotations)]
     fn cm_set_annotations(annotations_json: &str, file_path: &str);
+
+    /// window.__cm_set_inline_values(json)
+    #[wasm_bindgen(js_namespace = window, js_name = __cm_set_inline_values)]
+    fn cm_set_inline_values(json: &str);
 }
 
 /// Initialize the CodeMirror editor inside the given DOM element.
@@ -47,4 +51,9 @@ pub fn set_breakpoints(lines_json: &str) {
 /// Push annotations for the current file into the gutter.
 pub fn set_annotations(annotations_json: &str, file_path: &str) {
     cm_set_annotations(annotations_json, file_path);
+}
+
+/// Show inline variable values at specific lines in the editor.
+pub fn set_inline_values(json: &str) {
+    cm_set_inline_values(json);
 }

--- a/crates/debugium-ui/src/lib.rs
+++ b/crates/debugium-ui/src/lib.rs
@@ -2154,9 +2154,42 @@ fn SourcePanel(
                     });
                 }
                 editor::set_exec_line(line);
+
+                // Show inline variable values at the execution line
+                let vars = &state.variables;
+                if !vars.is_empty() {
+                    let inline: Vec<serde_json::Value> = {
+                        let mut items = Vec::new();
+                        let compact: Vec<String> = vars.iter()
+                            .filter(|v| !v.name.starts_with("__") && v.name != "special variables" && v.name != "function variables")
+                            .take(8)
+                            .map(|v| {
+                                let val = if v.value.len() > 40 {
+                                    format!("{}…", &v.value[..40])
+                                } else {
+                                    v.value.clone()
+                                };
+                                format!("{} = {}", v.name, val)
+                            })
+                            .collect();
+                        if !compact.is_empty() {
+                            items.push(serde_json::json!({
+                                "line": line,
+                                "text": compact.join(", ")
+                            }));
+                        }
+                        items
+                    };
+                    if let Ok(json) = serde_json::to_string(&inline) {
+                        editor::set_inline_values(&json);
+                    }
+                } else {
+                    editor::set_inline_values("[]");
+                }
             }
         } else {
             editor::set_exec_line(0);
+            editor::set_inline_values("[]");
         }
     });
 


### PR DESCRIPTION
## Summary
When the debugger pauses, local variable values now appear as faded italic text at the end of the execution line in the source editor.

- Shows up to 8 local variables inline, truncating values at 40 chars
- Filters out Python internals (`__dunder__`, "special variables", "function variables")
- Supports both dark and light themes
- Clears inline values when execution resumes or tab switches away from execution file

### Implementation
- **cm_init.js**: New `ViewPlugin` + `InlineValueWidget` using CodeMirror `Decoration.widget`
- **editor.rs**: New `set_inline_values(json)` Rust-JS bridge
- **lib.rs**: Formats locals from `SessionState.variables` and calls the bridge
- **style.css**: `.cm-inline-value` styling

## Test plan
- [x] Full test suite: 56 tests pass (no regressions)
- [x] Build compiles cleanly
- Visual testing recommended: launch a Python debug session and verify values appear

Closes #16

Made with [Cursor](https://cursor.com)