### PR TITLE
feat: memory inspection MCP tools + capability-gated tools/list

### DIFF
--- a/crates/debugium-server/src/mcp/mod.rs
+++ b/crates/debugium-server/src/mcp/mod.rs
@@ -63,9 +63,23 @@ impl RpcResponse {
 
 // ─── Tool definitions ────────────────────────────────────────────────────────
 
-fn tool_list() -> Value {
-    json!({
-        "tools": [
+/// Maps tool names to the DAP capability they require.
+/// Tools not in this list are always included.
+const CAPABILITY_GATED_TOOLS: &[(&str, &str)] = &[
+    ("read_memory",              "supportsReadMemoryRequest"),
+    ("write_memory",             "supportsWriteMemoryRequest"),
+    ("disassemble",              "supportsDisassembleRequest"),
+    ("set_function_breakpoints", "supportsFunctionBreakpoints"),
+    ("set_variable",             "supportsSetVariable"),
+    ("restart",                  "supportsRestartRequest"),
+    ("terminate",                "supportsTerminateRequest"),
+    ("get_exception_info",       "supportsExceptionInfoRequest"),
+];
+
+fn tool_list(adapter_caps: &Value) -> Value {
+    let has_session = adapter_caps.is_object() && !adapter_caps.as_object().unwrap().is_empty();
+
+    let all_tools = json!([
             {
                 "name": "get_sessions",
                 "description": "List all active debug sessions.",
@@ -626,6 +640,48 @@ fn tool_list() -> Value {
                 }
             },
             {
+                "name": "read_memory",
+                "description": "Read raw memory from the debuggee process. Primarily for native debugging (C/C++/Rust). Returns base64-encoded bytes. Requires adapter support (supportsReadMemoryRequest).",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "session_id": { "type": "string" },
+                        "memory_reference": { "type": "string", "description": "Memory reference (hex address or expression)." },
+                        "offset": { "type": "integer", "description": "Byte offset from the reference. Default: 0." },
+                        "count": { "type": "integer", "description": "Number of bytes to read. Default: 128." }
+                    },
+                    "required": ["memory_reference"]
+                }
+            },
+            {
+                "name": "write_memory",
+                "description": "Write raw bytes to the debuggee's memory. Use with extreme caution. Requires adapter support (supportsWriteMemoryRequest).",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "session_id": { "type": "string" },
+                        "memory_reference": { "type": "string", "description": "Memory address to write to." },
+                        "offset": { "type": "integer", "description": "Byte offset from the reference. Default: 0." },
+                        "data": { "type": "string", "description": "Base64-encoded bytes to write." }
+                    },
+                    "required": ["memory_reference", "data"]
+                }
+            },
+            {
+                "name": "disassemble",
+                "description": "Disassemble machine instructions at a memory address. Primarily for native debugging. Requires adapter support (supportsDisassembleRequest).",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "session_id": { "type": "string" },
+                        "memory_reference": { "type": "string", "description": "Memory address to start disassembly." },
+                        "offset": { "type": "integer", "description": "Byte offset. Default: 0." },
+                        "instruction_count": { "type": "integer", "description": "Number of instructions to disassemble. Default: 20." }
+                    },
+                    "required": ["memory_reference"]
+                }
+            },
+            {
                 "name": "launch_session",
                 "description": "Launch a new debug session autonomously. Spawns the debug adapter, connects, sets breakpoints, and waits until the session is paused (or running). Returns the session_id for use with all other tools.",
                 "inputSchema": {
@@ -722,8 +778,23 @@ fn tool_list() -> Value {
                     }
                 }
             }
-        ]
-    })
+    ]);
+
+    if !has_session {
+        return json!({ "tools": all_tools });
+    }
+
+    let filtered: Vec<Value> = all_tools.as_array().unwrap().iter().filter(|tool| {
+        let name = tool.get("name").and_then(Value::as_str).unwrap_or("");
+        for &(gated_name, cap_key) in CAPABILITY_GATED_TOOLS {
+            if name == gated_name {
+                return adapter_caps.get(cap_key).and_then(Value::as_bool).unwrap_or(false);
+            }
+        }
+        true
+    }).cloned().collect();
+
+    json!({ "tools": filtered })
 }
 
 // ─── Client capability tracking ──────────────────────────────────────────────
@@ -987,7 +1058,22 @@ async fn handle_request(
         "ping" => RpcResponse::ok(id, json!({})),
 
         // Tool discovery
-        "tools/list" => RpcResponse::ok(id, tool_list()),
+        "tools/list" => {
+            let adapter_caps = if let Some(port) = proxy_port {
+                match proxy_tool_via_http(port, "get_capabilities", json!({})).await {
+                    Ok(text) => serde_json::from_str::<Value>(&text).unwrap_or(json!({})),
+                    Err(_) => json!({}),
+                }
+            } else {
+                let ids = registry.list().await;
+                if let Some(sid) = ids.first() {
+                    if let Some(s) = registry.get(sid).await {
+                        s.get_capabilities().await
+                    } else { json!({}) }
+                } else { json!({}) }
+            };
+            RpcResponse::ok(id, tool_list(&adapter_caps))
+        }
 
         // Tool invocation
         "tools/call" => {

--- a/crates/debugium-server/src/mcp/tools.rs
+++ b/crates/debugium-server/src/mcp/tools.rs
@@ -1225,6 +1225,69 @@ pub async fn dispatch_tool(
             }
         }
 
+        // ── Memory inspection ────────────────────────────────────────
+        "read_memory" => {
+            let s = session.ok_or_else(|| anyhow::anyhow!("Session '{session_id}' not found"))?;
+            let caps = s.get_capabilities().await;
+            if !caps.get("supportsReadMemoryRequest").and_then(Value::as_bool).unwrap_or(false) {
+                return Ok("Adapter does not support readMemory (supportsReadMemoryRequest=false). This feature requires a native debugger like lldb-dap.".to_string());
+            }
+            let mem_ref = args.get("memory_reference").and_then(Value::as_str)
+                .ok_or_else(|| anyhow::anyhow!("`memory_reference` is required"))?;
+            let offset = args.get("offset").and_then(Value::as_i64).unwrap_or(0);
+            let count = args.get("count").and_then(Value::as_u64).unwrap_or(128);
+
+            let resp = s.client.request("readMemory", Some(json!({
+                "memoryReference": mem_ref,
+                "offset": offset,
+                "count": count,
+            }))).await?;
+            let body = resp.get("body").cloned().unwrap_or(json!(null));
+            Ok(serde_json::to_string_pretty(&body)?)
+        }
+
+        "write_memory" => {
+            let s = session.ok_or_else(|| anyhow::anyhow!("Session '{session_id}' not found"))?;
+            let caps = s.get_capabilities().await;
+            if !caps.get("supportsWriteMemoryRequest").and_then(Value::as_bool).unwrap_or(false) {
+                return Ok("Adapter does not support writeMemory (supportsWriteMemoryRequest=false).".to_string());
+            }
+            let mem_ref = args.get("memory_reference").and_then(Value::as_str)
+                .ok_or_else(|| anyhow::anyhow!("`memory_reference` is required"))?;
+            let offset = args.get("offset").and_then(Value::as_i64).unwrap_or(0);
+            let data = args.get("data").and_then(Value::as_str)
+                .ok_or_else(|| anyhow::anyhow!("`data` (base64) is required"))?;
+
+            let resp = s.client.request("writeMemory", Some(json!({
+                "memoryReference": mem_ref,
+                "offset": offset,
+                "data": data,
+            }))).await?;
+            let written = resp.get("body")
+                .and_then(|b| b.get("bytesWritten")).and_then(Value::as_u64).unwrap_or(0);
+            Ok(format!("Wrote {written} byte(s) to {mem_ref}+{offset}"))
+        }
+
+        "disassemble" => {
+            let s = session.ok_or_else(|| anyhow::anyhow!("Session '{session_id}' not found"))?;
+            let caps = s.get_capabilities().await;
+            if !caps.get("supportsDisassembleRequest").and_then(Value::as_bool).unwrap_or(false) {
+                return Ok("Adapter does not support disassemble (supportsDisassembleRequest=false).".to_string());
+            }
+            let mem_ref = args.get("memory_reference").and_then(Value::as_str)
+                .ok_or_else(|| anyhow::anyhow!("`memory_reference` is required"))?;
+            let offset = args.get("offset").and_then(Value::as_i64).unwrap_or(0);
+            let count = args.get("instruction_count").and_then(Value::as_u64).unwrap_or(20);
+
+            let resp = s.client.request("disassemble", Some(json!({
+                "memoryReference": mem_ref,
+                "offset": offset,
+                "instructionCount": count,
+            }))).await?;
+            let body = resp.get("body").cloned().unwrap_or(json!(null));
+            Ok(serde_json::to_string_pretty(&body)?)
+        }
+
         // ── Session lifecycle ─────────────────────────────────────
         "launch_session" => {
             let program_str = args.get("program").and_then(Value::as_str)

--- a/crates/debugium-server/tests/integration.rs
+++ b/crates/debugium-server/tests/integration.rs
@@ -1865,3 +1865,53 @@ fn aa3_import_session_restores_findings() {
     assert!(text.contains("findings: 2"), "expected 2 findings imported: {text}");
     assert!(text.contains("watches: 1"), "expected 1 watch imported: {text}");
 }
+
+// ─── AB. Memory inspection + capability gating ────────────────────────────────
+
+#[test]
+fn ab1_memory_tools_listed_without_session() {
+    let mut p = McpProc::start(7331);
+    p.initialize();
+    let r = p.send("tools/list", Some(serde_json::json!({})));
+    p.stop();
+    let tools_json = serde_json::to_string(&r).unwrap();
+    assert!(tools_json.contains("read_memory"), "read_memory not in tools/list (no session)");
+    assert!(tools_json.contains("write_memory"), "write_memory not in tools/list (no session)");
+    assert!(tools_json.contains("disassemble"), "disassemble not in tools/list (no session)");
+}
+
+#[test]
+fn ab2_memory_tools_hidden_for_python() {
+    require_debugpy!();
+    let srv = ServerGuard::launch(7436, Some(43), None);
+    assert!(srv.wait_up(12), "AB2 server never started");
+    assert!(srv.wait_paused(12), "AB2 session never paused");
+
+    let mut p = McpProc::start(7436);
+    p.initialize();
+    let r = p.send("tools/list", Some(serde_json::json!({})));
+    p.stop();
+
+    let tools_json = serde_json::to_string(&r).unwrap();
+    assert!(!tools_json.contains("\"read_memory\""), "read_memory should be hidden for Python");
+    assert!(!tools_json.contains("\"write_memory\""), "write_memory should be hidden for Python");
+    assert!(!tools_json.contains("\"disassemble\""), "disassemble should be hidden for Python");
+}
+
+#[test]
+fn ab3_python_still_shows_supported_tools() {
+    require_debugpy!();
+    let srv = ServerGuard::launch(7437, Some(43), None);
+    assert!(srv.wait_up(12), "AB3 server never started");
+    assert!(srv.wait_paused(12), "AB3 session never paused");
+
+    let mut p = McpProc::start(7437);
+    p.initialize();
+    let r = p.send("tools/list", Some(serde_json::json!({})));
+    p.stop();
+
+    let tools_json = serde_json::to_string(&r).unwrap();
+    assert!(tools_json.contains("\"get_debug_context\""), "get_debug_context missing");
+    assert!(tools_json.contains("\"step_over\""), "step_over missing");
+    assert!(tools_json.contains("\"set_breakpoints\""), "set_breakpoints missing");
+}


### PR DESCRIPTION
## Summary
- Adds `read_memory`, `write_memory`, `disassemble` MCP tools for native debugging (C/C++/Rust via lldb-dap)
- `tools/list` now filters by adapter capabilities — tools whose required DAP capability is unsupported are hidden
- Capability gating table covers: memory ops, disassemble, function breakpoints, set_variable, restart, terminate, exception info
- In proxy mode, capabilities are fetched from the running server before building the tool list

Supersedes #26, Closes #17

## Test plan
- [x] `ab1_memory_tools_listed_without_session` — all tools shown when no session
- [x] `ab2_memory_tools_hidden_for_python` — memory tools hidden with Python adapter
- [x] `ab3_python_still_shows_supported_tools` — core tools remain visible
- [x] All 75 tests pass

Made with [Cursor](https://cursor.com)