### PR TITLE
fix: gate clear_data_breakpoints on adapter capability

### DIFF
--- a/crates/debugium-server/src/mcp/tools.rs
+++ b/crates/debugium-server/src/mcp/tools.rs
@@ -380,9 +380,14 @@ pub async fn dispatch_tool(
 
         "clear_data_breakpoints" => {
             let s = session.ok_or_else(|| anyhow::anyhow!("Session '{session_id}' not found"))?;
+            let caps = s.get_capabilities().await;
+            let supports_data_bp = caps.get("supportsDataBreakpoints")
+                .and_then(Value::as_bool).unwrap_or(false);
             let count = s.data_breakpoints.read().await.len();
             s.data_breakpoints.write().await.clear();
-            s.client.request("setDataBreakpoints", Some(json!({ "breakpoints": [] }))).await?;
+            if supports_data_bp {
+                s.client.request("setDataBreakpoints", Some(json!({ "breakpoints": [] }))).await?;
+            }
             Ok(format!("Cleared {count} data breakpoint(s)."))
         }
 


### PR DESCRIPTION
## Summary
- `clear_data_breakpoints` sent `setDataBreakpoints` to the DAP adapter without checking `supportsDataBreakpoints` first, causing the request to hang indefinitely on adapters like debugpy that don't support data breakpoints
- Now checks the capability before issuing the DAP request, matching how `set_data_breakpoint` already works

## Test plan
- [x] Verified live: `clear_data_breakpoints` on Python session now returns instantly instead of hanging
- [x] All 75 integration tests pass
- [x] `cargo build --release` clean

Made with [Cursor](https://cursor.com)