### PR TITLE
fix: resolve issues #33, #35, #36, #37

### DIFF
--- a/crates/debugium-server/src/dap/adapter.rs
+++ b/crates/debugium-server/src/dap/adapter.rs
@@ -268,6 +268,7 @@ impl AdapterKind {
 /// Information about a spawned adapter process.
 pub struct AdapterProcess {
     pub pid: u32,
+    #[allow(dead_code)]
     pub argv: String,
 }
 

--- a/crates/debugium-server/src/dap/client.rs
+++ b/crates/debugium-server/src/dap/client.rs
@@ -6,11 +6,9 @@ use anyhow::{Context, Result};
 use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
-use tokio::process::{Child, ChildStdin, ChildStdout};
+use tokio::process::{Child, ChildStdin};
 use tokio::sync::{mpsc, oneshot, RwLock};
 use tracing::{debug, error, warn};
-
-use dap_types::DapMessage;
 
 type PendingMap = Arc<RwLock<HashMap<u32, oneshot::Sender<Value>>>>;
 
@@ -20,6 +18,7 @@ pub struct DapClient {
     seq: AtomicU32,
     sender: mpsc::Sender<String>,
     pending: PendingMap,
+    #[allow(dead_code)]
     event_tx: mpsc::Sender<Value>,
 }
 

--- a/crates/debugium-server/src/dap/session.rs
+++ b/crates/debugium-server/src/dap/session.rs
@@ -138,6 +138,7 @@ pub struct Session {
 
 impl Session {
     /// Returns true if the adapter declared support for the given capability key.
+    #[allow(dead_code)]
     pub async fn supports(&self, cap: &str) -> bool {
         self.capabilities.read().await
             .get(cap)

--- a/crates/debugium-server/src/home.rs
+++ b/crates/debugium-server/src/home.rs
@@ -47,7 +47,6 @@ impl DebugiumHome {
                 // Check if the process is still alive (signal 0 = existence check)
                 #[cfg(unix)]
                 {
-                    use std::os::unix::process::CommandExt;
                     // kill(pid, 0) returns 0 if process exists
                     let alive = unsafe { libc::kill(pid as i32, 0) } == 0;
                     if !alive {

--- a/crates/debugium-server/src/mcp/mod.rs
+++ b/crates/debugium-server/src/mcp/mod.rs
@@ -297,12 +297,12 @@ fn tool_list(adapter_caps: &Value) -> Value {
             },
             {
                 "name": "step_until",
-                "description": "Step over repeatedly until a Python/JS expression evaluates to truthy, or until max_steps is reached. Returns the debug context at the stopping point. Much more efficient than calling step_over + evaluate in a loop.",
+                "description": "Step over repeatedly until a runtime expression evaluates to truthy in the debuggee's language scope (e.g. Python: x > 5, JavaScript: items.length > 0), or until max_steps is reached. The condition is evaluated in the current stack frame — not debugger metadata. Much more efficient than calling step_over + evaluate in a loop.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
                         "session_id": { "type": "string" },
-                        "condition": { "type": "string", "description": "Expression to evaluate after each step (e.g. 'counter.value > 50', 'result != None')." },
+                        "condition": { "type": "string", "description": "Runtime expression in the debuggee's language, evaluated in the current stack frame after each step (e.g. Python: 'x > 5', JavaScript: 'i < arr.length'). Uses variables and syntax of the target language." },
                         "max_steps": { "type": "integer", "description": "Maximum steps before giving up. Default 20." },
                         "thread_id": { "type": "integer", "description": "Thread to step. Default 1." }
                     },

--- a/crates/debugium-server/src/mcp/tools.rs
+++ b/crates/debugium-server/src/mcp/tools.rs
@@ -885,7 +885,18 @@ pub async fn dispatch_tool(
                 }).collect::<Vec<_>>().into_iter().rev().collect()
             };
 
-            Ok(serde_json::to_string_pretty(&json!({
+            // Check if we're actually stopped on an exception (exceptionId meaningful)
+            let looks_like_non_exception = exc_info.get("exceptionId")
+                .and_then(Value::as_str)
+                .map(|s| s.is_empty() || s.to_lowercase().contains("unknown"))
+                .unwrap_or(true);
+            let note = if looks_like_non_exception {
+                "Note: not currently stopped on an exception. The data below reflects the current stack frame, not an actual exception.\n\n"
+            } else {
+                ""
+            };
+
+            let result_json = json!({
                 "exception": exc_info,
                 "paused_at": format!("{}:{} in {}()",
                     file.split('/').last().unwrap_or(&file), line, func),
@@ -899,7 +910,9 @@ pub async fn dispatch_tool(
                 "source_window": source_window,
                 "recent_output": recent_output,
                 "recent_timeline": recent_timeline,
-            }))?)
+            });
+            let json_str = serde_json::to_string_pretty(&result_json)?;
+            Ok(format!("{note}{json_str}"))
         }
 
         "disconnect" => {
@@ -923,6 +936,16 @@ pub async fn dispatch_tool(
             let log_message = args.get("log_message")
                 .or_else(|| args.get("message"))
                 .and_then(Value::as_str).map(str::to_string);
+
+            // Gate logpoints on adapter capability (same pattern as set_data_breakpoint)
+            if log_message.is_some() {
+                let caps = s.get_capabilities().await;
+                let supports_log_points = caps.get("supportsLogPoints")
+                    .and_then(Value::as_bool).unwrap_or(false);
+                if !supports_log_points {
+                    return Ok("Adapter does not support log points (supportsLogPoints=false).".to_string());
+                }
+            }
 
             let new_spec = BpSpec { line, condition: condition.clone(), hit_condition: hit_condition.clone(), log_message: log_message.clone() };
 

--- a/crates/debugium-server/src/server/hub.rs
+++ b/crates/debugium-server/src/server/hub.rs
@@ -83,6 +83,7 @@ impl Hub {
     }
 
     /// List all active session IDs.
+    #[allow(dead_code)]
     pub async fn session_ids(&self) -> Vec<String> {
         self.sessions.read().await.keys().cloned().collect()
     }

--- a/crates/debugium-server/src/server/mod.rs
+++ b/crates/debugium-server/src/server/mod.rs
@@ -34,7 +34,7 @@ pub async fn start(
         session_counter: Arc::new(AtomicU32::new(1)),
     };
 
-    let static_dir_for_index = static_dir.clone();
+    let _static_dir_for_index = static_dir.clone();
     let app = Router::new()
         .route("/ws", get(routes::ws_handler))
         .route("/source", get(routes::source_handler))

--- a/crates/debugium-server/src/server/routes.rs
+++ b/crates/debugium-server/src/server/routes.rs
@@ -8,7 +8,6 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json, Response};
 use serde::Deserialize;
 use serde_json::{json, Value};
-use tokio::sync::broadcast;
 use tracing::{debug, warn};
 
 use dap_types::WsCommand;

--- a/crates/debugium-ui/src/lib.rs
+++ b/crates/debugium-ui/src/lib.rs
@@ -564,7 +564,7 @@ pub fn App() -> impl IntoView {
                                                 "session": id_state,
                                                 "msg": ev
                                             });
-                                            if let Ok(env) = serde_json::from_value::<WsEnvelope>(envelope) {
+                                            if let Ok(_env) = serde_json::from_value::<WsEnvelope>(envelope) {
                                                 // Get thread from stopped event and request stack
                                                 let thread_id = ev.get("body")
                                                     .and_then(|b| b.get("threadId"))
@@ -2814,7 +2814,7 @@ fn CompletionsDropdown(
     active_session: ReadSignal<Option<String>>,
     session_data: RwSignal<std::collections::HashMap<String, SessionState>>,
     eval_expr: RwSignal<String>,
-    selected: RwSignal<usize>,
+    _selected: RwSignal<usize>,
     show: RwSignal<bool>,
 ) -> impl IntoView {
     let comps_signal = move || {
@@ -3077,7 +3077,7 @@ fn ConsolePanel(
                             active_session=active_session
                             session_data=session_data
                             eval_expr=eval_expr
-                            selected=selected_completion
+                            _selected=selected_completion
                             show=show_completions
                         />
                     </Show>


### PR DESCRIPTION
## Summary
- **#33**: Gate `set_logpoint` on `supportsLogPoints` capability — returns helpful message if adapter doesn't support log points
- **#35**: `explain_exception` now warns when not stopped on an actual exception (checks `exceptionId` for "unknown"/empty)
- **#36**: `step_until` tool description clarifies condition is a runtime expression in the debuggee's language (e.g., `x > 5`), not debugger metadata
- **#37**: Clean up all compiler warnings — removed unused imports, prefixed unused variables, annotated intentional dead code

Closes #33, closes #35, closes #36, closes #37

## Test plan
- [x] `cargo build --release` — zero warnings
- [x] All 75 integration tests pass

Made with [Cursor](https://cursor.com)