### PR TITLE
Fix marketplace config structure for Claude Code plugin discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,7 @@
 {
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "debugium",
+  "description": "AI-driven debugger for multiple languages via DAP adapters and MCP tools.",
   "owner": {
     "name": "Algiras",
     "url": "https://github.com/Algiras"
@@ -7,12 +9,9 @@
   "plugins": [
     {
       "name": "debugium",
-      "source": {
-        "source": "github",
-        "repo": "Algiras/debugium"
-      },
+      "source": ".",
       "description": "AI-driven debugger for Python, JavaScript, TypeScript, Rust, Java, C/C++, Scala, and WebAssembly. Control live debug sessions via MCP tools: launch or attach to processes, set breakpoints, inspect variables, step through execution, and trace bugs using DAP adapters.",
-      "version": "0.1.0",
+      "version": "0.1.3",
       "author": { "name": "Algiras" },
       "homepage": "https://github.com/Algiras/debugium",
       "repository": "https://github.com/Algiras/debugium",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,10 +1,12 @@
 {
   "name": "debugium",
-  "version": "0.1.0",
+  "version": "0.1.3",
   "description": "AI-driven debugger for Python, JavaScript, TypeScript, Rust, Java, C/C++, Scala, and WebAssembly. Control live debug sessions via MCP tools: launch or attach to processes, set breakpoints, inspect variables, step through execution, evaluate expressions, and trace bugs using DAP adapters.",
   "author": { "name": "Algiras" },
   "license": "MIT",
   "keywords": ["debugger", "dap", "mcp", "python", "rust", "javascript", "typescript", "breakpoints", "llm-debugging"],
   "homepage": "https://github.com/Algiras/debugium",
-  "repository": "https://github.com/Algiras/debugium"
+  "repository": "https://github.com/Algiras/debugium",
+  "mcpServers": "./.mcp.json",
+  "skills": ["./skills/debugium/SKILL.md"]
 }


### PR DESCRIPTION
## Summary
- Move `marketplace.json` into `.claude-plugin/` where Claude Code expects it and add `$schema` field
- Declare `mcpServers` and `skills` components in `plugin.json` so the plugin is fully discoverable
- Bump plugin.json version to 0.1.3 to match package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)